### PR TITLE
Exclude artifacts from jcenter and maven central

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mantis-api
 
-[![Build Status](https://img.shields.io/travis/Netflix/mantis-api.svg)](https://travis-ci.org/Netflix/mantis-api)
+[![Build Status](https://img.shields.io/travis/com/Netflix/mantis-api.svg)](https://travis-ci.com/Netflix/mantis-api)
 [![OSS Lifecycle](https://img.shields.io/osslifecycle/Netflix/mantis-api.svg)](https://github.com/Netflix/mantis-api)
 [![License](https://img.shields.io/github/license/Netflix/mantis-api.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,8 @@ ext {
     jettyVersion = '9.4.12.v20180830'
     jsonVersion = '20160810'
     junitVersion = '4.10'
-    mantisClientVersion = '1.+'
-    mantisDiscoveryProtoVersion = '1.+'
+    mantisClientVersion = '1.2.+'
+    mantisDiscoveryProtoVersion = '1.2.+'
     mockitoVersion = '1.9.5'
     s3Version = '1.11.566'
     servletApiVersion = '3.1.0'
@@ -50,6 +50,16 @@ apply plugin: 'java-library'
 apply plugin: 'checkstyle'
 apply plugin: 'pmd'
 apply plugin: 'application'
+
+bintray {
+    pkg {
+        version {
+            mavenCentralSync {
+                sync = false
+            }
+        }
+    }
+}
 
 group = 'io.mantisrx'
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ ext {
     archaiusVersion = '2.3.+'
     assetjCoreVersion = '3.11.1'
     guavaVersion = '18.+'
+    gsonVersion = '2.8.+'
     guiceVersion = '4.1.0'
     jettyVersion = '9.4.12.v20180830'
     jsonVersion = '20160810'
@@ -98,6 +99,7 @@ dependencies {
 
     implementation "javax.servlet:javax.servlet-api:$servletApiVersion"
 
+    implementation "com.google.code.gson:gson:$gsonVersion"
     implementation "com.google.guava:guava:$guavaVersion"
     implementation "com.google.inject:guice:$guiceVersion"
 

--- a/buildViaTravis.sh
+++ b/buildViaTravis.sh
@@ -6,7 +6,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$GRADLE_PUBLISH" == "false" ]; th
   ./gradlew build --stacktrace
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
   echo -e 'Build master with Snapshot'
-  ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" build snapshot --stacktrace
+  ./gradlew -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" snapshot --stacktrace
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch => Branch ['$TRAVIS_BRANCH']'
   ./gradlew build --stacktrace


### PR DESCRIPTION
### Context

Don't publish this artifact to jcenter and maven central. Users that
wish to still use these packages, e.g., decorate, these packages
can pull directly from the Netflix OSS Bintray.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
