### PR TITLE
switch backend of job cluster discovery info lookup to use MantisMast…

### DIFF
--- a/src/main/java/io/mantisrx/api/MantisAPIServer.java
+++ b/src/main/java/io/mantisrx/api/MantisAPIServer.java
@@ -159,7 +159,7 @@ public class MantisAPIServer {
 
         servletContextHandler.addServlet(new ServletHolder(new JobSchedulingInfoServlet(this.mantisClient, propertyRepository, registry, workerThreadPool)), "/api/v1/jobs/" + JobSchedulingInfoServlet.endpointName + "/*");
         helpMsgs.add(JobSchedulingInfoServlet.helpMsg);
-        servletContextHandler.addServlet(new ServletHolder(new JobClusterDiscoveryInfoServlet(this.mantisClient, propertyRepository, registry, workerThreadPool)), "/" + JobClusterDiscoveryInfoServlet.endpointName + "/*");
+        servletContextHandler.addServlet(new ServletHolder(new JobClusterDiscoveryInfoServlet(masterClientWrapper, this.mantisClient, propertyRepository, registry, workerThreadPool)), "/" + JobClusterDiscoveryInfoServlet.endpointName + "/*");
         helpMsgs.add(JobClusterDiscoveryInfoServlet.helpMsg);
         servletContextHandler.addServlet(new ServletHolder(new JobClusterDiscoveryInfoWebSocketServlet(this.mantisClient, propertyRepository, registry, workerThreadPool)), "/" + JobClusterDiscoveryInfoWebSocketServlet.endpointName + "/*");
         servletContextHandler.addServlet(new ServletHolder(new JobClusterDiscoveryInfoWebSocketServlet(this.mantisClient, propertyRepository, registry, workerThreadPool)), "/api/v1/" + JobClusterDiscoveryInfoWebSocketServlet.endpointName + "/*");

--- a/src/main/java/io/mantisrx/api/PropertyNames.java
+++ b/src/main/java/io/mantisrx/api/PropertyNames.java
@@ -32,7 +32,9 @@ public class PropertyNames {
     public static final String mantisAPICacheExpirySeconds = "mantisapi.cache.expiry.secs";
     public static final String mantisAPICacheSize = "mantisapi.cache.size";
     public static final String mantisAPICacheEnabled = "mantisapi.cache.enabled";
-
+    public static final String mantisLatestJobDiscoveryInfoEndpointEnabled = "mantis.latest.job.discovery.info.get.enabled";
+    public static final String mantisLatestJobDiscoveryCacheTtlMs = "mantis.latest.job.discovery.info.cache.ttl.ms";
+    public static final String mantisLatestJobDiscoveryMasterTimeoutMs = "mantis.latest.job.discovery.info.master.timeout.ms";
 
     public static final String samplingInterval = "mantisapi.job.sink.connector.source.job.min.sample.interval.millis";
 

--- a/src/main/java/io/mantisrx/api/handlers/servlets/JobClusterDiscoveryInfoServlet.java
+++ b/src/main/java/io/mantisrx/api/handlers/servlets/JobClusterDiscoveryInfoServlet.java
@@ -18,16 +18,25 @@ package io.mantisrx.api.handlers.servlets;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
+import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyRepository;
-import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
+import io.mantisrx.api.PropertyNames;
 import io.mantisrx.api.SessionContext;
 import io.mantisrx.api.SessionContextBuilder;
 import io.mantisrx.api.SpectatorUtils;
@@ -35,11 +44,19 @@ import io.mantisrx.api.WorkerThreadPool;
 import io.mantisrx.api.handlers.utils.HttpUtils;
 import io.mantisrx.api.handlers.utils.JobDiscoveryInfoManager;
 import io.mantisrx.api.handlers.utils.JobDiscoveryLookupKey;
+import io.mantisrx.api.handlers.utils.MantisClientUtil;
 import io.mantisrx.api.handlers.utils.PathUtils;
 import io.mantisrx.client.MantisClient;
+import io.mantisrx.server.core.JobSchedulingInfo;
+import io.mantisrx.server.core.json.DefaultObjectMapper;
+import io.mantisrx.server.master.client.MasterClientWrapper;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
+
 
 
 /**
@@ -49,22 +66,95 @@ public class JobClusterDiscoveryInfoServlet extends HttpServlet {
 
     private static final long serialVersionUID = JobClusterDiscoveryInfoServlet.class.hashCode();
 
-    @SuppressWarnings("unused")
     private static Logger logger = LoggerFactory.getLogger(JobClusterDiscoveryInfoServlet.class);
+    private transient final MasterClientWrapper masterClientWrapper;
     private transient final MantisClient mantisClient;
     public static final String endpointName = "jobClusters/discoveryInfo";
     public static final String helpMsg = endpointName + "/<JobCluster>";
-    private final ObjectMapper mapper = new ObjectMapper();
     private transient final Registry registry;
     private transient final WorkerThreadPool workerThreadPool;
     private transient final PropertyRepository propertyRepository;
+    /**
+     * Fast property to toggle between the old SSE based job discovery info lookup which would establish two long lived connections
+     * and the new request response endpoint to retrieve the discovery info with one API call
+     */
+    private transient final Property<Boolean> latestJobDiscoveryInfoEndpointEnabled;
+    private transient final Property<Integer> cacheExpiryTtlMillis;
+    private transient final Property<Integer> masterTimeoutMillis;
+    private final LoadingCache<String, Tuple2<HttpResponseStatus, Optional<JobSchedulingInfo>>> discoveryInfoCache;
 
+    private static final String JOB_CLUSTER_LATEST_JOB_DISCOVERY_ENDPOINT = "/api/v1/jobClusters/%s/latestJobDiscoveryInfo";
+    private static final ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).registerModule(new Jdk8Module());
 
-    public JobClusterDiscoveryInfoServlet(MantisClient mantisClient, PropertyRepository propertyRepository, Registry registry, WorkerThreadPool workerThreadPool) {
+    public JobClusterDiscoveryInfoServlet(MasterClientWrapper masterClientWrapper,
+                                          MantisClient mantisClient,
+                                          PropertyRepository propertyRepository,
+                                          Registry registry,
+                                          WorkerThreadPool workerThreadPool) {
+        this.masterClientWrapper = masterClientWrapper;
         this.mantisClient = mantisClient;
         this.registry = registry;
         this.workerThreadPool = workerThreadPool;
         this.propertyRepository = propertyRepository;
+        this.latestJobDiscoveryInfoEndpointEnabled = propertyRepository.get(PropertyNames.mantisLatestJobDiscoveryInfoEndpointEnabled, Boolean.class).orElse(true);
+        this.cacheExpiryTtlMillis = propertyRepository.get(PropertyNames.mantisLatestJobDiscoveryCacheTtlMs, Integer.class).orElse(250);
+        this.masterTimeoutMillis = propertyRepository.get(PropertyNames.mantisLatestJobDiscoveryMasterTimeoutMs, Integer.class).orElse(1000);
+
+        Integer cacheTtlMillis = cacheExpiryTtlMillis.get();
+        logger.info("cache TTL {}", cacheTtlMillis);
+        discoveryInfoCache = Caffeine.newBuilder()
+            .expireAfterWrite(cacheTtlMillis, TimeUnit.MILLISECONDS)
+            .maximumSize(500)
+            .build(this::jobSchedInfo);
+    }
+
+    private Tuple2<HttpResponseStatus, Optional<JobSchedulingInfo>> jobSchedInfo(String jobCluster) {
+        String uri = String.format(JOB_CLUSTER_LATEST_JOB_DISCOVERY_ENDPOINT, jobCluster);
+
+        try {
+            Tuple2<HttpResponseStatus, Optional<JobSchedulingInfo>> resp = MantisClientUtil
+                .callGetOnMaster(masterClientWrapper.getMasterMonitor().getMasterObservable(), uri, registry)
+                .flatMap(mr -> {
+                    HttpResponseStatus status = mr.getStatus();
+                    return mr.getByteBuf()
+                        .map(bb -> {
+                            Optional<JobSchedulingInfo> jsi = Optional.empty();
+                            try {
+                                String responseContent = bb.toString(Charsets.UTF_8);
+                                logger.debug("master response content {}", responseContent);
+                                if (status.code() == 200 && !Strings.isNullOrEmpty(responseContent)) {
+                                    JobSchedulingInfo jobSchedulingInfo = DefaultObjectMapper.getInstance().readValue(responseContent, JobSchedulingInfo.class);
+                                    jsi = Optional.ofNullable(jobSchedulingInfo);
+                                    SpectatorUtils.buildAndRegisterCounter(registry, "jobClusterDiscoveryInfoCacheRefreshSuccess", "endpoint", endpointName, "jobCluster", jobCluster).increment();
+                                } else {
+                                    logger.info("failed to get JobSchedulingInfo for {} MantisMaster response (status={}, content={})", jobCluster, status.code(), responseContent);
+                                    SpectatorUtils.buildAndRegisterCounter(registry, "jobClusterDiscoveryCacheRefreshFailed", "endpoint", endpointName,
+                                                                           "reason", "status_"+status.code(), "jobCluster", jobCluster).increment();
+                                }
+                            } catch (IOException e) {
+                                logger.info("failed to parse JobSchedulingInfo for {} MantisMaster response (status={}, content={})", uri, status.code(), bb.toString(Charsets.UTF_8));
+                                SpectatorUtils.buildAndRegisterCounter(registry, "jobClusterDiscoveryCacheRefreshFailed", "endpoint", endpointName,
+                                                                       "reason", "exc_"+e.getClass().getSimpleName(), "jobCluster", jobCluster).increment();
+                            }
+                            return Tuple.of(status, jsi);
+                        });
+                })
+                .timeout(masterTimeoutMillis.get(), TimeUnit.MILLISECONDS, Observable.error(new Exception("timed out waiting for JobSchedulingInfo from MantisMaster")))
+                .doOnError((t) -> {
+                    logger.warn("Timed out getting discovery info " + uri);
+                    SpectatorUtils.buildAndRegisterCounter(registry, "jobClusterDiscoveryCacheRefreshFailed",
+                                                           "reason", "TimedOut", "jobCluster", jobCluster).increment();
+                    return;
+                })
+                .toBlocking()
+                .first();
+            return resp;
+        } catch (Exception e) {
+            logger.info("caught exception getting discovery info for {}", jobCluster, e);
+            SpectatorUtils.buildAndRegisterCounter(registry, "jobClusterDiscoveryCacheRefreshFailed", "endpoint", endpointName,
+                                                   "reason", "exc_" + e.getClass().getSimpleName(), "jobCluster", jobCluster).increment();
+            return Tuple.of(HttpResponseStatus.INTERNAL_SERVER_ERROR, Optional.empty());
+        }
     }
 
 
@@ -74,11 +164,25 @@ public class JobClusterDiscoveryInfoServlet extends HttpServlet {
         response.setStatus(HttpServletResponse.SC_NO_CONTENT);
     }
 
+    private SessionContext getSessionContext(HttpServletRequest request) {
+        final SessionContextBuilder contextBuilder = SessionContextBuilder.getInstance(propertyRepository, registry, workerThreadPool);
+        return contextBuilder
+            .createHttpSessionCtx(request.getRemoteAddr(),
+                                  request.getRequestURI() + "?" + request.getQueryString(),
+                                  request.getMethod());
+    }
+
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) {
-        final SessionContextBuilder contextBuilder = SessionContextBuilder.getInstance(propertyRepository, registry, workerThreadPool);
-        final SessionContext httpSessionCtx = contextBuilder.createHttpSessionCtx(request.getRemoteAddr(),
-                request.getRequestURI() + "?" + request.getQueryString(), request.getMethod());
+        if (latestJobDiscoveryInfoEndpointEnabled.get()) {
+            latestJobDiscoveryInfoEndpointGET(request, response);
+        } else {
+            sseNamedJobInfoAndAssignmentResultsGET(request, response);
+        }
+    }
+
+    private void WithJobClusterAndSessionContext(HttpServletRequest request, HttpServletResponse response, BiConsumer<String, SessionContext> jobClusterFn) {
+        final SessionContext httpSessionCtx = getSessionContext(request);
 
         String jobCluster = PathUtils.getTokenAfter(request.getPathInfo(), "");
         if (jobCluster == null || jobCluster.isEmpty()) {
@@ -88,7 +192,7 @@ public class JobClusterDiscoveryInfoServlet extends HttpServlet {
                 response.flushBuffer();
             } catch (Exception e) {
                 logger.warn("Couldn't write message (\"Job cluster not specified\") to client session {}",
-                        httpSessionCtx.getId(), e);
+                            httpSessionCtx.getId(), e);
             }
             SpectatorUtils.buildAndRegisterCounter(registry, "jobClusterDiscoveryInfoFailed", "endpoint", endpointName, "reason", "jobClusterNullOrEmpty").increment();
             httpSessionCtx.endSession();
@@ -96,7 +200,13 @@ public class JobClusterDiscoveryInfoServlet extends HttpServlet {
         }
         SpectatorUtils.buildAndRegisterCounter(registry, "jobClusterDiscoveryInfoRequest", "endpoint", endpointName, "jobCluster", jobCluster).increment();
 
-        String jobDiscoveryInfo = JobDiscoveryInfoManager.getInstance(mantisClient, registry)
+        jobClusterFn.accept(jobCluster, httpSessionCtx);
+    }
+
+    private void sseNamedJobInfoAndAssignmentResultsGET(HttpServletRequest request, HttpServletResponse response) {
+        WithJobClusterAndSessionContext(request, response, (jobCluster, httpSessionCtx) -> {
+
+            String jobDiscoveryInfo = JobDiscoveryInfoManager.getInstance(mantisClient, registry)
                 .jobDiscoveryInfoStream(new JobDiscoveryLookupKey(JobDiscoveryLookupKey.LookupType.JOB_CLUSTER, jobCluster))
                 .map((jSchedInfo) -> {
                     try {
@@ -114,7 +224,7 @@ public class JobClusterDiscoveryInfoServlet extends HttpServlet {
                 .timeout(2, TimeUnit.SECONDS, Observable.error(new Exception("timed out waiting for JobSchedulingInfo")))
                 .doOnError((t) -> {
                     logger.warn("Timed out relaying request for session id " + httpSessionCtx.getId() +
-                            " url=" + request.getRequestURI());
+                                    " url=" + request.getRequestURI());
                     SpectatorUtils.buildAndRegisterCounter(registry, "jobClusterDiscoveryInfoFailed", "endpoint", endpointName,
                                                            "reason", "TimedOut", "jobCluster", jobCluster).increment();
                     response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -132,14 +242,58 @@ public class JobClusterDiscoveryInfoServlet extends HttpServlet {
                 .toBlocking()
                 .value();
 
-        response.setStatus(HttpServletResponse.SC_OK);
-        try {
-            response.getOutputStream().print(jobDiscoveryInfo);
-            response.flushBuffer();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+            response.setStatus(HttpServletResponse.SC_OK);
+            try {
+                response.getOutputStream().print(jobDiscoveryInfo);
+                response.flushBuffer();
+            } catch (IOException e) {
+                logger.warn("caught exc sending job discovery info for {}", jobCluster, e);
+            }
 
-        httpSessionCtx.endSession();
+            httpSessionCtx.endSession();
+        });
+    }
+
+    private void latestJobDiscoveryInfoEndpointGET(HttpServletRequest request, HttpServletResponse response) {
+        WithJobClusterAndSessionContext(request, response, (jobCluster, httpSessionCtx) -> {
+            try {
+                String uri = request.getRequestURI();
+                if (request.getQueryString() != null && !request.getQueryString().isEmpty())
+                    uri = uri + "?" + request.getQueryString();
+                logger.debug("JobCluster discovery info request " + uri);
+                // lookup from loading cache
+                Tuple2<HttpResponseStatus, Optional<JobSchedulingInfo>> result = discoveryInfoCache.get(jobCluster);
+                if (result != null) {
+                    HttpResponseStatus status = result._1;
+                    Optional<JobSchedulingInfo> jsi = result._2;
+                    if (jsi.isPresent()) {
+                        HttpUtils.addBaseHeaders(response, "GET");
+                        String serializedSchedInfo = mapper.writeValueAsString(jsi.get());
+                        SpectatorUtils.buildAndRegisterCounter(registry, "jobClusterDiscoveryInfoSuccess", "endpoint", endpointName, "jobCluster", jobCluster).increment();
+
+                        response.setStatus(HttpResponseStatus.OK.code());
+                        response.getOutputStream().print(serializedSchedInfo);
+                        response.flushBuffer();
+
+                    } else {
+                        SpectatorUtils.buildAndRegisterCounter(registry, "jobClusterDiscoveryInfoFailed", "endpoint", endpointName, "reason", "JobSchedulingInfoEmpty").increment();
+                        response.setStatus(status.code());
+                        response.getOutputStream().print("job discovery info lookup failed for "+jobCluster);
+                        response.flushBuffer();
+                    }
+                } else {
+                    SpectatorUtils.buildAndRegisterCounter(registry, "jobClusterDiscoveryInfoFailed", "endpoint", endpointName, "reason", "CacheLookupFailed").increment();
+                    logger.info("failed to lookup job discovery info for {}", jobCluster);
+                    response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                    response.getOutputStream().print("error getting job discovery info for "+jobCluster);
+                    response.flushBuffer();
+                }
+            } catch (IOException e) {
+                SpectatorUtils.buildAndRegisterCounter(registry, "jobClusterDiscoveryInfoFailed", "endpoint", endpointName, "reason", "exc_"+e.getClass().getSimpleName()).increment();
+                logger.warn("caught exception handling request for job discovery info {}", jobCluster, e);
+            } finally {
+                httpSessionCtx.endSession();
+            }
+        });
     }
 }


### PR DESCRIPTION
…er latestJobDiscoveryInfo endpoint

### Context

Before the change :
GET /jobClusters/discoveryInfo impl made two API calls to the Mantis Master which returned SSE responses :
1. Get SSE stream of the latest job ID given a job cluster
2. Get workers(discoveryInfo) for the latest job ID

After change:
GET /jobClusters/discoveryInfo impl makes one API calls to the Mantis Master which returns a single response:
1. Get workers of the latest job ID given a job cluster

Implementation controlled by a dynamic property:
For rollback, set `mantis.latest.job.discovery.info.get.enabled` to `false` for disabling the new code path

### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
