### PR TITLE
rename __any__ to __default__

### DIFF
--- a/conf/local.properties
+++ b/conf/local.properties
@@ -17,4 +17,4 @@ mantisapi.submit.instanceLimit=100
 
 mantis.sse.disablePingFiltering=true
 
-mreAppJobClusterMap={"version": "1", "timestamp": 12345, "mappings": {"__default__": {"requestEventStream": "SharedPushRequestEventSource","sentryEventStream": "SentryLogEventSource","__any__": "SharedPushEventSource"},"customApp": {"logEventStream": "CustomAppEventSource","sentryEventStream": "CustomAppSentryLogSource"}}}
+mreAppJobClusterMap={"version": "1", "timestamp": 12345, "mappings": {"__default__": {"requestEventStream": "SharedPushRequestEventSource","sentryEventStream": "SentryLogEventSource","__default__": "SharedPushEventSource"},"customApp": {"logEventStream": "CustomAppEventSource","sentryEventStream": "CustomAppSentryLogSource"}}}


### PR DESCRIPTION
### Context

If mantis-publish client publishes to a stream name that has no explicit mapping specified on mantis-api then it should use the mapping configured for __default__ instead of __any__

### Checklist

- [ x] `./gradlew build` compiles code correctly
- [ x] Added new tests where applicable
- [ x] `./gradlew test` passes all tests
- [ x] Extended README or added javadocs where applicable
- [ x] Added copyright headers for new files from `CONTRIBUTING.md`
