### PR TITLE
Add file based caching for artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ COPY ./build/install/mantis-api/lib/* /apps/nfmantisapi/lib/
 
 COPY ./conf/local.properties /apps/nfmantisapi/conf/
 
+RUN mkdir -p /apps/nfmantisapi/mantisArtifacts
+RUN mkdir -p /logs/mantisapi
+
 WORKDIR /apps/nfmantisapi
 
 ENTRYPOINT [ "bin/mantis-api", "-p", "conf/local.properties" ]

--- a/conf/local.properties
+++ b/conf/local.properties
@@ -17,4 +17,7 @@ mantisapi.submit.instanceLimit=100
 
 mantis.sse.disablePingFiltering=true
 
+mantisapi.artifact.disk.cache.location=/apps/nfmantisapi/mantisArtifacts/
+mantisapi.artifact.disk.cache.enabled=true
+
 mreAppJobClusterMap={"version": "1", "timestamp": 12345, "mappings": {"__default__": {"requestEventStream": "SharedPushRequestEventSource","sentryEventStream": "SentryLogEventSource","__default__": "SharedPushEventSource"},"customApp": {"logEventStream": "CustomAppEventSource","sentryEventStream": "CustomAppSentryLogSource"}}}

--- a/src/main/java/io/mantisrx/api/LocalFileBasedArtifactManager.java
+++ b/src/main/java/io/mantisrx/api/LocalFileBasedArtifactManager.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.api;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.netflix.archaius.api.Property;
+import com.netflix.archaius.api.PropertyRepository;
+import io.mantisrx.api.handlers.domain.Artifact;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A simple artifact store that is backed by an optional file system store. For use in dev/testing only.
+ * For production use consider a distributed file store like S3 etc.
+ */
+public class LocalFileBasedArtifactManager implements ArtifactManager {
+
+    private static Logger logger = LoggerFactory.getLogger(LocalFileBasedArtifactManager.class);
+    private Map<String, Artifact> artifacts = new HashMap<>();
+    private final String artifactStoreLocation;
+    private final boolean enableDiskCache;
+
+    public LocalFileBasedArtifactManager(PropertyRepository propertyRepository) {
+        // Root directory for store artifacts
+        Property<String> artifactStoreLocationProp = propertyRepository.get(PropertyNames.artifactRepositoryLocation,
+                String.class).orElse("/tmp/");
+
+        artifactStoreLocation = artifactStoreLocationProp.get();
+
+        // Disable writing to local file system (Maintains artifacts in memory only)
+        Property<Boolean> cacheArtifactsLocally = propertyRepository.get(PropertyNames.artifactCacheEnabled,
+                Boolean.class).orElse(false);
+
+        this.enableDiskCache = cacheArtifactsLocally.get();
+
+        logger.info("LocalFileBased Artifact Manager initialized! Store to Local File system enabled is {} "
+                + "Artifact directory set to {}", enableDiskCache, artifactStoreLocation);
+    }
+
+    /**
+     * For unit testing.
+     * @param artifactStoreLocation
+     */
+    LocalFileBasedArtifactManager(String artifactStoreLocation, boolean enableDiskCache) {
+        this.artifactStoreLocation = artifactStoreLocation;
+        this.enableDiskCache = enableDiskCache;
+
+    }
+
+    @Override
+    public List<String> getArtifacts() {
+        if(enableDiskCache && artifacts.isEmpty()) {
+            loadArtifacts(artifacts, artifactStoreLocation);
+        }
+        return artifacts
+                .values()
+                .stream()
+                .map(Artifact::getFileName)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Artifact> getArtifact(String name) {
+        if(artifacts.containsKey(name)) {
+            return Optional.of(artifacts.get(name));
+        } else {
+            if(enableDiskCache) {
+                Optional<byte[]> fileBytes = readFromFile(Paths.get(artifactStoreLocation + name));
+                if (fileBytes.isPresent()) {
+
+                    Artifact artifact = new Artifact(name, fileBytes.get().length, fileBytes.get());
+                    artifacts.put(name, artifact);
+                    return Optional.of(artifact);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void deleteArtifact(String name) {
+        this.artifacts.remove(name);
+        if(enableDiskCache) {
+            Path path = Paths.get(artifactStoreLocation + name);
+            if (Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+                try {
+                    Files.delete(path);
+                    logger.debug("File {} deleted successfully", path);
+                } catch (IOException e) {
+                    logger.warn("Exception {} deleting file {}", e, path);
+                }
+            }
+        }
+
+    }
+
+    @Override
+    public void putArtifact(Artifact artifact) {
+        Objects.requireNonNull(artifact, "Artifact cannot be null");
+        this.artifacts.put(artifact.getFileName(), artifact);
+        if(enableDiskCache) {
+            String path = artifactStoreLocation + artifact.getFileName();
+            writeToFile(artifact.getContent(), Paths.get(path));
+        }
+    }
+
+
+    private void loadArtifacts(Map<String, Artifact> artifacts, String artifactStoreLocation) {
+        Path path = Paths.get(artifactStoreLocation);
+        if(!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+            try {
+                Files.createDirectory(path);
+            } catch (IOException e) {
+                logger.error("Exception {} creating artifact dir ", e);
+            }
+            return;
+        } else {
+            try {
+                Stream<Path> fileList = Files.list(path);
+                fileList
+                        .filter((fileName) -> {
+                            if(fileName.getFileName().toString().endsWith("json")
+                                    || fileName.getFileName().toString().endsWith("zip")) {
+                                return true;
+                            }
+                            return false;
+                        })
+                        .map((fileName)-> {
+                            Optional<byte[]> bytesO = readFromFile(fileName);
+                            if(bytesO.isPresent()) {
+                                return new Artifact(fileName.getFileName().toString(),
+                                        bytesO.get().length,
+                                        bytesO.get());
+                            } else {
+                                return null;
+                            }
+                        }).filter(Objects::nonNull)
+                        .forEach((artifact) -> {
+                            artifacts.put(artifact.getFileName(), artifact);
+                        });
+                    logger.info("Loaded {} files from filesystem", artifacts.size());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+
+    /*package protected*/ Optional<byte[]> readFromFile(Path path) {
+        logger.debug("Reading file {} ", path);
+        if(Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+            try {
+                byte[] data = Files.readAllBytes(path);
+                logger.debug("Read file {} ", path);
+                return Optional.of(data);
+            } catch (IOException e) {
+                logger.error("Error {} reading from file {}", e, path);
+            }
+        } else {
+            logger.warn("File {} doesn't exist", path);
+        }
+        return Optional.empty();
+    }
+
+    /*package protected*/ boolean writeToFile(byte [] fileData, Path path) {
+
+        try {
+            if(Files.isWritable(path.getParent())) {
+                Files.write(path,fileData);
+                logger.debug("{} written successfully to disk ", path);
+            } else {
+                logger.warn("File {} is not writeable", path);
+            }
+        } catch (Exception e) {
+            logger.error("Exception: {} saving file {}", e, path);
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/io/mantisrx/api/MantisAPIModule.java
+++ b/src/main/java/io/mantisrx/api/MantisAPIModule.java
@@ -103,9 +103,13 @@ public class MantisAPIModule extends AbstractModule {
 
         bind(WorkerThreadPool.class).toInstance(new WorkerThreadPool(registry, threads));
         bind(StreamingClientFactory.class).to(DummyStreamingClientFactory.class);
-
-        bind(ArtifactManager.class).to(InMemoryArtifactManager.class);
     }
+
+    @Provides
+    ArtifactManager getArtifactManager(PropertyRepository propertyRepository) {
+        return new LocalFileBasedArtifactManager(propertyRepository);
+    }
+
 
     @Provides
     MasterClientWrapper getMasterClientWrapper(Properties properties) {

--- a/src/main/java/io/mantisrx/api/PropertyNames.java
+++ b/src/main/java/io/mantisrx/api/PropertyNames.java
@@ -32,6 +32,8 @@ public class PropertyNames {
     public static final String mantisAPICacheExpirySeconds = "mantisapi.cache.expiry.secs";
     public static final String mantisAPICacheSize = "mantisapi.cache.size";
     public static final String mantisAPICacheEnabled = "mantisapi.cache.enabled";
+    public static final String artifactRepositoryLocation = "mantisapi.artifact.disk.cache.location";
+    public static final String artifactCacheEnabled = "mantisapi.artifact.disk.cache.enabled";
     public static final String mantisLatestJobDiscoveryInfoEndpointEnabled = "mantis.latest.job.discovery.info.get.enabled";
     public static final String mantisLatestJobDiscoveryCacheTtlMs = "mantis.latest.job.discovery.info.cache.ttl.ms";
     public static final String mantisLatestJobDiscoveryMasterTimeoutMs = "mantis.latest.job.discovery.info.master.timeout.ms";

--- a/src/main/java/io/mantisrx/api/handlers/domain/Artifact.java
+++ b/src/main/java/io/mantisrx/api/handlers/domain/Artifact.java
@@ -16,12 +16,17 @@
 
 package io.mantisrx.api.handlers.domain;
 
+import java.util.Objects;
+
+
 public class Artifact {
     private long sizeInBytes;
     private String fileName;
     private byte[] content;
 
     public Artifact(String fileName, long sizeInBytes, byte[] content) {
+        Objects.requireNonNull(fileName, "File name cannot be null");
+        Objects.requireNonNull(content, "Content cannot be null");
         this.fileName = fileName;
         this.sizeInBytes = sizeInBytes;
         this.content = content;

--- a/src/test/java/io/mantisrx/api/LocalFileBasedArtifactManagerTest.java
+++ b/src/test/java/io/mantisrx/api/LocalFileBasedArtifactManagerTest.java
@@ -1,0 +1,533 @@
+package io.mantisrx.api;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.mantisrx.api.handlers.domain.Artifact;
+import org.junit.Test;
+
+
+public class LocalFileBasedArtifactManagerTest {
+    private static final String ROOT_DIR = "/tmp";
+    @Test
+    public void writeAndReadTest() {
+        String baseDirStr = ROOT_DIR + "/writeAndReadTest";
+        Path baseDir = Paths.get(baseDirStr);
+        try {
+
+            if(Files.exists(baseDir, LinkOption.NOFOLLOW_LINKS)) {
+                cleanUpDir(baseDir);
+            }
+            Files.createDirectory(baseDir);
+            LocalFileBasedArtifactManager artifactManager = new LocalFileBasedArtifactManager(
+                    baseDirStr + "/",true);
+            String data = "{\n"
+                    + "  \"jobInfo\": {\n"
+                    + "    \"name\": \"PushRequestEventSourceJob\",\n"
+                    + "    \"description\": \"Fetches request events from any source in a distributed manner. "
+                    + "The output is served via HTTP server using SSE protocol.\",\n"
+                    + "    \"numberOfStages\": 1,\n"
+                    + "    \"parameterInfo\": {\n"
+                    + "      \"bufferDurationMillis\": {\n"
+                    + "        \"name\": \"bufferDurationMillis\",\n"
+                    + "        \"description\": \"millis to buffer events before processing\",\n"
+                    + "        \"defaultValue\": \"250\",\n"
+                    + "        \"validatorDescription\": \"range >=100<=1000\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Integer\"\n"
+                    + "      },\n"
+                    + "      \"mantis.jobmaster.autoscale.metric\": {\n"
+                    + "        \"name\": \"mantis.jobmaster.autoscale.metric\",\n"
+                    + "        \"description\": \"Custom autoscale metric for Job Master to use with UserDefined "
+                    + "Scaling Strategy. Format: <metricGroup>::<metricName>::<algo> where metricGroup and metricName "
+                    + "should exactly match the metric published via Mantis MetricsRegistry and algo = MAX/AVERAGE\",\n"
+                    + "        \"defaultValue\": \"\",\n"
+                    + "        \"validatorDescription\": \"always passes validation\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"String\"\n"
+                    + "      },\n"
+                    + "      \"zoneList\": {\n"
+                    + "        \"name\": \"zoneList\",\n"
+                    + "        \"description\": \"list of Zones\",\n"
+                    + "        \"defaultValue\": \"\",\n"
+                    + "        \"validatorDescription\": \"always passes validation\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"String\"\n"
+                    + "      },\n"
+                    + "      \"mantis.jobmaster.clutch.experimental.enabled\": {\n"
+                    + "        \"name\": \"mantis.jobmaster.clutch.experimental.enabled\",\n"
+                    + "        \"description\": \"Enables the experimental version of the Clutch autoscaler. "
+                    + "Note this is different from the Clutch used in production today.\",\n"
+                    + "        \"defaultValue\": \"false\",\n"
+                    + "        \"validatorDescription\": \"always passes validation\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Boolean\"\n"
+                    + "      },\n"
+                    + "      \"mantis.netty.useSingleThread\": {\n"
+                    + "        \"name\": \"mantis.netty.useSingleThread\",\n"
+                    + "        \"description\": \"use single netty thread\",\n"
+                    + "        \"defaultValue\": \"false\",\n"
+                    + "        \"validatorDescription\": \"always passes validation\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Boolean\"\n"
+                    + "      },\n"
+                    + "      \"mantis.w2w.spsc\": {\n"
+                    + "        \"name\": \"mantis.w2w.spsc\",\n"
+                    + "        \"description\": \"Whether to use spsc or blocking queue\",\n"
+                    + "        \"defaultValue\": \"false\",\n"
+                    + "        \"validatorDescription\": \"always passes validation\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Boolean\"\n"
+                    + "      },\n"
+                    + "      \"mantis.sse.spsc\": {\n"
+                    + "        \"name\": \"mantis.sse.spsc\",\n"
+                    + "        \"description\": \"Whether to use spsc or blocking queue for SSE\",\n"
+                    + "        \"defaultValue\": \"false\",\n"
+                    + "        \"validatorDescription\": \"always passes validation\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Boolean\"\n"
+                    + "      },\n"
+                    + "      \"mantis.stageConcurrency\": {\n"
+                    + "        \"name\": \"mantis.stageConcurrency\",\n"
+                    + "        \"description\": \"Number of cores to use for stage processing\",\n"
+                    + "        \"defaultValue\": \"-1\",\n"
+                    + "        \"validatorDescription\": \"range >=-1<=16\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Integer\"\n"
+                    + "      },\n"
+                    + "      \"mantis.w2w.toKeyThreads\": {\n"
+                    + "        \"name\": \"mantis.w2w.toKeyThreads\",\n"
+                    + "        \"description\": \"number of drainer threads on the ScalarToKey stage\",\n"
+                    + "        \"defaultValue\": \"1\",\n"
+                    + "        \"validatorDescription\": \"range >=1<=8\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Integer\"\n"
+                    + "      },\n"
+                    + "      \"nettyThreadCount\": {\n"
+                    + "        \"name\": \"nettyThreadCount\",\n"
+                    + "        \"description\": null,\n"
+                    + "        \"defaultValue\": \"4\",\n"
+                    + "        \"validatorDescription\": \"range >=1<=8\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Integer\"\n"
+                    + "      },\n"
+                    + "      \"mantis.sse.bufferCapacity\": {\n"
+                    + "        \"name\": \"mantis.sse.bufferCapacity\",\n"
+                    + "        \"description\": \"buffer on SSE per connection\",\n"
+                    + "        \"defaultValue\": \"25000\",\n"
+                    + "        \"validatorDescription\": \"range >=1<=100000\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Integer\"\n"
+                    + "      },\n"
+                    + "      \"MANTIS_WORKER_JVM_OPTS_STAGE0\": {\n"
+                    + "        \"name\": \"MANTIS_WORKER_JVM_OPTS_STAGE0\",\n"
+                    + "        \"description\": \"command line options for stage 0 mantis worker JVM, "
+                    + "setting this field would override the default GC settings\",\n"
+                    + "        \"defaultValue\": \"\",\n"
+                    + "        \"validatorDescription\": \"always passes validation\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"String\"\n"
+                    + "      },\n"
+                    + "      \"MANTIS_WORKER_JVM_OPTS_STAGE1\": {\n"
+                    + "        \"name\": \"MANTIS_WORKER_JVM_OPTS_STAGE1\",\n"
+                    + "        \"description\": \"command line options for stage 1 mantis worker JVM, "
+                    + "setting this field would override the default GC settings\",\n"
+                    + "        \"defaultValue\": \"\",\n"
+                    + "        \"validatorDescription\": \"always passes validation\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"String\"\n"
+                    + "      },\n"
+                    + "      \"mantis.w2w.toKeyMaxChunkSize\": {\n"
+                    + "        \"name\": \"mantis.w2w.toKeyMaxChunkSize\",\n"
+                    + "        \"description\": \"batch size for bytes drained from Scalar To Key stage\",\n"
+                    + "        \"defaultValue\": \"1000\",\n"
+                    + "        \"validatorDescription\": \"range >=1<=100000\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Integer\"\n"
+                    + "      },\n"
+                    + "      \"targetApp\": {\n"
+                    + "        \"name\": \"targetApp\",\n"
+                    + "        \"description\": \"target app\",\n"
+                    + "        \"defaultValue\": \"\",\n"
+                    + "        \"validatorDescription\": \"always passes validation\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"String\"\n"
+                    + "      },\n"
+                    + "      \"targetASGs\": {\n"
+                    + "        \"name\": \"targetASGs\",\n"
+                    + "        \"description\": \"target ASGs CSV regex\",\n"
+                    + "        \"defaultValue\": \"\",\n"
+                    + "        \"validatorDescription\": \"always passes validation\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"String\"\n"
+                    + "      },\n"
+                    + "      \"mantis.EnableCompressedBinary\": {\n"
+                    + "        \"name\": \"mantis.EnableCompressedBinary\",\n"
+                    + "        \"description\": \"Enables binary compression of SSE data\",\n"
+                    + "        \"defaultValue\": \"false\",\n"
+                    + "        \"validatorDescription\": \"always passes validation\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Boolean\"\n"
+                    + "      },\n"
+                    + "      \"mantis.w2w.toKeyBuffer\": {\n"
+                    + "        \"name\": \"mantis.w2w.toKeyBuffer\",\n"
+                    + "        \"description\": \"per connection buffer from Scalar To Key stage\",\n"
+                    + "        \"defaultValue\": \"50000\",\n"
+                    + "        \"validatorDescription\": \"range >=1<=100000\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Integer\"\n"
+                    + "      },\n"
+                    + "      \"MANTIS_WORKER_JVM_OPTS\": {\n"
+                    + "        \"name\": \"MANTIS_WORKER_JVM_OPTS\",\n"
+                    + "        \"description\": \"command line options for the mantis worker JVM, setting this field "
+                    + "would override the default GC settings\",\n"
+                    + "        \"defaultValue\": \"\",\n"
+                    + "        \"validatorDescription\": \"always passes validation\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"String\"\n"
+                    + "      },\n"
+                    + "      \"mantis.sse.maxReadTimeMSec\": {\n"
+                    + "        \"name\": \"mantis.sse.maxReadTimeMSec\",\n"
+                    + "        \"description\": \"interval at which buffer is drained to write to SSE\",\n"
+                    + "        \"defaultValue\": \"250\",\n"
+                    + "        \"validatorDescription\": \"range >=1<=100000\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Integer\"\n"
+                    + "      },\n"
+                    + "      \"mantis.sse.numConsumerThreads\": {\n"
+                    + "        \"name\": \"mantis.sse.numConsumerThreads\",\n"
+                    + "        \"description\": \"number of consumer threads draining the queue to write to SSE\",\n"
+                    + "        \"defaultValue\": \"1\",\n"
+                    + "        \"validatorDescription\": \"range >=1<=8\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Integer\"\n"
+                    + "      },\n"
+                    + "      \"mantis.jobmaster.clutch.config\": {\n"
+                    + "        \"name\": \"mantis.jobmaster.clutch.config\",\n"
+                    + "        \"description\": \"Configuration for the clutch autoscaler.\",\n"
+                    + "        \"defaultValue\": \"\",\n"
+                    + "        \"validatorDescription\": \"always passes validation\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"String\"\n"
+                    + "      },\n"
+                    + "      \"mantis.sse.maxChunkSize\": {\n"
+                    + "        \"name\": \"mantis.sse.maxChunkSize\",\n"
+                    + "        \"description\": \"SSE chunk size\",\n"
+                    + "        \"defaultValue\": \"1000\",\n"
+                    + "        \"validatorDescription\": \"range >=1<=100000\",\n"
+                    + "        \"required\": false,\n"
+                    + "        \"parameterType\": \"Integer\"\n"
+                    + "      }\n"
+                    + "    },\n"
+                    + "    \"sourceInfo\": null,\n"
+                    + "    \"sinkInfo\": null,\n"
+                    + "    \"stages\": {\n"
+                    + "      \"0\": {\n"
+                    + "        \"stageNumber\": 0,\n"
+                    + "        \"description\": null\n"
+                    + "      }\n"
+                    + "    }\n"
+                    + "  },\n"
+                    + "  \"project\": \"mantis-source-job-publish\",\n"
+                    + "  \"version\": \"1.3.0-SNAPSHOT\",\n"
+                    + "  \"timestamp\": 1570564886521,\n"
+                    + "  \"readyForJobMaster\": true\n"
+                    + "}";
+            ObjectMapper mapper = new ObjectMapper();
+
+            byte[] bytes = data.getBytes(StandardCharsets.UTF_8); //mapper.writeValueAsBytes(data);
+            artifactManager.putArtifact(new Artifact("myart.json",bytes.length, bytes));
+
+            Optional<Artifact> artifactOP = artifactManager.getArtifact("myart.json");
+            assertTrue(artifactOP.isPresent());
+
+            byte[] content = artifactOP.get().getContent();
+            String readData = new String(content);
+
+            assertEquals(data, readData);
+
+        } catch (Exception e) {
+            
+            e.printStackTrace();
+            fail();
+        } finally {
+            cleanUpDir(baseDir);
+        }
+
+    }
+
+    @Test
+    public void nonExistentArtifact() {
+        String baseDirStr = ROOT_DIR + "/nonExistentArtifact";
+        Path baseDir = Paths.get(baseDirStr);
+        try {
+
+            if (Files.exists(baseDir, LinkOption.NOFOLLOW_LINKS)) {
+                cleanUpDir(baseDir);
+            }
+            Files.createDirectory(baseDir);
+
+            LocalFileBasedArtifactManager artifactManager =
+                    new LocalFileBasedArtifactManager(baseDirStr +"/",true);
+
+            assertFalse(artifactManager.getArtifact("nonExistent.json").isPresent());
+
+        } catch(Exception e) {
+
+        } finally {
+            cleanUpDir(baseDir);
+        }
+    }
+
+    @Test
+    public void nullArtifactTest() {
+        String baseDirStr = ROOT_DIR + "/nullArtifactTest";
+        Path baseDir = Paths.get(baseDirStr);
+        try {
+
+            if (Files.exists(baseDir, LinkOption.NOFOLLOW_LINKS)) {
+                cleanUpDir(baseDir);
+            }
+            Files.createDirectory(baseDir);
+
+            LocalFileBasedArtifactManager artifactManager =
+                    new LocalFileBasedArtifactManager(baseDirStr +"/",true);
+
+            artifactManager.putArtifact(null);
+            fail();
+
+        } catch(Exception e) {
+            e.printStackTrace();
+
+        } finally {
+            cleanUpDir(baseDir);
+        }
+    }
+
+    @Test
+    public void readTest() {
+        String baseDirStr = ROOT_DIR + "/readTest";
+        Path baseDir = Paths.get(baseDirStr);
+        try {
+
+            if(Files.exists(baseDir, LinkOption.NOFOLLOW_LINKS)) {
+                cleanUpDir(baseDir);
+            }
+            Files.createDirectory(baseDir);
+            String someData = "This is some data!";
+            writeData(someData, baseDirStr + "/somedata.json");
+            LocalFileBasedArtifactManager artifactManager = new LocalFileBasedArtifactManager(baseDirStr +"/",true);
+
+            Optional<Artifact> artifactOP = artifactManager.getArtifact("somedata.json");
+
+            assertTrue(artifactOP.isPresent());
+
+            byte[] content = artifactOP.get().getContent();
+            String readData = new String(content);
+
+            assertEquals(someData, readData);
+
+
+        } catch(Exception e) {
+            e.printStackTrace();
+            fail();
+        } finally {
+            cleanUpDir(baseDir);
+        }
+    }
+
+    @Test
+    public void listFilesTest() {
+        String baseDirStr = ROOT_DIR + "/listFilesTest";
+        Path baseDir = Paths.get(baseDirStr);
+        try {
+
+            if(Files.exists(baseDir, LinkOption.NOFOLLOW_LINKS)) {
+                cleanUpDir(baseDir);
+            }
+            Files.createDirectory(baseDir);
+
+            String someData = "This is some data!";
+            String file1 = "somedata.json";
+            String someData2 = "This is some data!";
+            String file2 = "somedata2.json";
+            writeData(someData, baseDirStr +"/" + file1);
+            writeData(someData2, baseDirStr + "/" + file2);
+
+            LocalFileBasedArtifactManager artifactManager =
+                    new LocalFileBasedArtifactManager(baseDirStr + "/",true);
+            List<String> artifacts = artifactManager.getArtifacts();
+            boolean foundFile1 = false;
+            boolean foundFile2 = false;
+            for(String artifact : artifacts) {
+                System.out.println("Processing " + artifact);
+                if(file1.equals(artifact)) {
+
+                    foundFile1 = true;
+                    Optional<Artifact> artifactOp = artifactManager.getArtifact(artifact);
+                    assertTrue(artifactOp.isPresent());
+                    String data1 = new String(artifactOp.get().getContent(), StandardCharsets.UTF_8);
+                    assertEquals(someData, data1);
+                } else if(file2.equals(artifact)) {
+                    foundFile2 = true;
+                    Optional<Artifact> artifactOp = artifactManager.getArtifact(artifact);
+                    assertTrue(artifactOp.isPresent());
+                    String data2 = new String(artifactOp.get().getContent(), StandardCharsets.UTF_8);
+                    assertEquals(someData2, data2);
+                }
+
+            }
+            assertTrue(foundFile1 && foundFile2);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        } finally {
+            cleanUpDir(baseDir);
+        }
+    }
+
+    @Test
+    public void localDiskCacheDisabledListFileTest() {
+        String baseDirStr = ROOT_DIR + "/localDiskCacheDisabledTest";
+        Path baseDir = Paths.get(baseDirStr);
+        try {
+
+            if (Files.exists(baseDir, LinkOption.NOFOLLOW_LINKS)) {
+                cleanUpDir(baseDir);
+            }
+            Files.createDirectory(baseDir);
+
+            String someData = "This is some data!";
+            String file1 = "somedata.json";
+            String someData2 = "This is some data!";
+            String file2 = "somedata2.json";
+            writeData(someData, baseDirStr + "/" + file1);
+            writeData(someData2, baseDirStr + "/" + file2);
+
+            LocalFileBasedArtifactManager artifactManager =
+                    new LocalFileBasedArtifactManager(baseDirStr + "/",false);
+
+            // should not read from local filesystem.
+            assertTrue(artifactManager.getArtifacts().isEmpty());
+
+        } catch(Exception e) {
+            fail();
+        } finally {
+            cleanUpDir(baseDir);
+        }
+    }
+
+    @Test
+    public void localDiskCacheDisabledGetFileTest() {
+        String baseDirStr = ROOT_DIR + "/localDiskCacheDisabledGetFileTest";
+        Path baseDir = Paths.get(baseDirStr);
+        try {
+
+            if (Files.exists(baseDir, LinkOption.NOFOLLOW_LINKS)) {
+                cleanUpDir(baseDir);
+            }
+            Files.createDirectory(baseDir);
+
+            String someData = "This is some data!";
+            String file1 = "somedata.json";
+
+            writeData(someData, baseDirStr + "/" + file1);
+
+
+            LocalFileBasedArtifactManager artifactManager =
+                    new LocalFileBasedArtifactManager(baseDirStr + "/",false);
+
+            // should not read from local filesystem.
+            assertFalse(artifactManager.getArtifact("somedata.json").isPresent());
+
+
+        } catch(Exception e) {
+            fail();
+        } finally {
+            cleanUpDir(baseDir);
+        }
+    }
+
+    @Test
+    public void localDiskCacheDisabledPutFileTest() {
+        String baseDirStr = ROOT_DIR + "/localDiskCacheDisabledPutFileTest";
+        Path baseDir = Paths.get(baseDirStr);
+        try {
+
+            if (Files.exists(baseDir, LinkOption.NOFOLLOW_LINKS)) {
+                cleanUpDir(baseDir);
+            }
+            Files.createDirectory(baseDir);
+
+            String someData = "This is some data!";
+            String file1 = "somedata.json";
+
+           // writeData(someData, baseDirStr + "/" + file1);
+
+
+            LocalFileBasedArtifactManager artifactManager =
+                    new LocalFileBasedArtifactManager(baseDirStr + "/",false);
+
+            // should not write to local filesystem.
+            byte [] dataInBytes = someData.getBytes(StandardCharsets.UTF_8);
+            artifactManager.putArtifact(new Artifact("somedata.json",dataInBytes.length,dataInBytes));
+
+            artifactManager =
+                    new LocalFileBasedArtifactManager(baseDirStr + "/",false);
+
+            // As the file was not written to disk the getArtifact should return empty.
+            assertFalse(artifactManager.getArtifact("somedata.json").isPresent());
+
+
+        } catch(Exception e) {
+            fail();
+        } finally {
+            cleanUpDir(baseDir);
+        }
+    }
+
+
+
+    private void cleanUpDir(Path baseDir) {
+
+        try {
+            Files.list(baseDir).forEach((p) -> {
+                try {
+                    System.out.println("Cleaning file " + p);
+                    Files.deleteIfExists(p);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            });
+            Files.delete(baseDir);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void writeData(String someData, String fileName) throws Exception {
+        OutputStream os = new FileOutputStream(fileName);
+
+        os.write(someData.getBytes(StandardCharsets.UTF_8));
+        //logger.info("{} written successfully to disk ", fileName);
+
+        // Close the file
+        os.close();
+
+    }
+}


### PR DESCRIPTION
### Context

Optionally store artifacts to disk. This helps in preloading job artifacts in local docker setup.

### Checklist

- [ x] `./gradlew build` compiles code correctly
- [ x] Added new tests where applicable
- [ x] `./gradlew test` passes all tests
- [ x] Extended README or added javadocs where applicable
- [ x] Added copyright headers for new files from `CONTRIBUTING.md`
