### PR TITLE
copy mantis-examples artifacts to mantis-api docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,25 @@ COPY ./conf/local.properties /apps/nfmantisapi/conf/
 RUN mkdir -p /apps/nfmantisapi/mantisArtifacts
 RUN mkdir -p /logs/mantisapi
 
+# OPTIONAL - To bootstrap mantis api with job artifacts. Assumes mantis-examples have been built.
+# copy examples
+COPY ./mantis-examples-twitter-sample-0.1.0-SNAPSHOT.zip /apps/nfmantisapi/mantisArtifacts/
+COPY ./mantis-examples-twitter-sample-0.1.0-SNAPSHOT.json /apps/nfmantisapi/mantisArtifacts/
+COPY ./mantis-examples-sine-function-0.1.0-SNAPSHOT.zip /apps/nfmantisapi/mantisArtifacts/
+COPY ./mantis-examples-sine-function-0.1.0-SNAPSHOT.json /apps/nfmantisapi/mantisArtifacts/
+COPY ./mantis-examples-groupby-sample-0.1.0-SNAPSHOT.zip /apps/nfmantisapi/mantisArtifacts/
+COPY ./mantis-examples-groupby-sample-0.1.0-SNAPSHOT.json /apps/nfmantisapi/mantisArtifacts/
+COPY ./mantis-examples-synthetic-sourcejob-0.1.0-SNAPSHOT.zip /apps/nfmantisapi/mantisArtifacts/
+COPY ./mantis-examples-synthetic-sourcejob-0.1.0-SNAPSHOT.json /apps/nfmantisapi/mantisArtifacts/
+COPY ./mantis-examples-jobconnector-sample-0.1.0-SNAPSHOT.zip /apps/nfmantisapi/mantisArtifacts/
+COPY ./mantis-examples-jobconnector-sample-0.1.0-SNAPSHOT.json /apps/nfmantisapi/mantisArtifacts/
+
+# copy source jobs
+COPY ./mantis-source-job-kafka-1.3.0-SNAPSHOT.zip /apps/nfmantisapi/mantisArtifacts/
+COPY ./mantis-source-job-kafka-1.3.0-SNAPSHOT.json /apps/nfmantisapi/mantisArtifacts/
+COPY ./mantis-source-job-publish-1.3.0-SNAPSHOT.zip /apps/nfmantisapi/mantisArtifacts/
+COPY ./mantis-source-job-publish-1.3.0-SNAPSHOT.json /apps/nfmantisapi/mantisArtifacts/
+
 WORKDIR /apps/nfmantisapi
 
 ENTRYPOINT [ "bin/mantis-api", "-p", "conf/local.properties" ]

--- a/buildDockerImage.sh
+++ b/buildDockerImage.sh
@@ -3,7 +3,26 @@
 # create the mantisapi binary
 ./gradlew clean installDist
 
+cp ../mantis-examples/twitter-sample/build/distributions/mantis-examples-twitter-sample-0.1.0-SNAPSHOT.zip .
+cp ../mantis-examples/twitter-sample/build/distributions/mantis-examples-twitter-sample-0.1.0-SNAPSHOT.json .
+cp ../mantis-examples/sine-function/build/distributions/mantis-examples-sine-function-0.1.0-SNAPSHOT.zip .
+cp ../mantis-examples/sine-function/build/distributions/mantis-examples-sine-function-0.1.0-SNAPSHOT.json .
+cp ../mantis-examples/groupby-sample/build/distributions/mantis-examples-groupby-sample-0.1.0-SNAPSHOT.zip .
+cp ../mantis-examples/groupby-sample/build/distributions/mantis-examples-groupby-sample-0.1.0-SNAPSHOT.json .
+cp ../mantis-examples/synthetic-sourcejob/build/distributions/mantis-examples-synthetic-sourcejob-0.1.0-SNAPSHOT.zip .
+cp ../mantis-examples/synthetic-sourcejob/build/distributions/mantis-examples-synthetic-sourcejob-0.1.0-SNAPSHOT.json .
+cp ../mantis-examples/jobconnector-sample/build/distributions/mantis-examples-jobconnector-sample-0.1.0-SNAPSHOT.zip .
+cp ../mantis-examples/jobconnector-sample/build/distributions/mantis-examples-jobconnector-sample-0.1.0-SNAPSHOT.json .
+cp ../mantis-examples/jobconnector-sample/build/distributions/mantis-examples-jobconnector-sample-0.1.0-SNAPSHOT.json .
+
+cp ../mantis-source-jobs/kafka-source-job/build/distributions/mantis-source-job-kafka-1.3.0-SNAPSHOT.zip .
+cp ../mantis-source-jobs/kafka-source-job/build/distributions/mantis-source-job-kafka-1.3.0-SNAPSHOT.json .
+
+cp ../mantis-source-jobs/publish-source-job/build/distributions/mantis-source-job-publish-1.3.0-SNAPSHOT.json .
+cp ../mantis-source-jobs/publish-source-job/build/distributions/mantis-source-job-publish-1.3.0-SNAPSHOT.zip .
+
 # build the docker image
-docker build -t netflixoss/mantisapi .
+
+docker build -t dev/mantisapi .
 
 echo "Created Docker image 'netflixoss/mantisapi'"


### PR DESCRIPTION
### Context

Copy prebuilt mantis example artifacts to mantis-api docker image.

### Checklist

- [x ] `./gradlew build` compiles code correctly
- [ x] Added new tests where applicable
- [ x] `./gradlew test` passes all tests
- [ x] Extended README or added javadocs where applicable
- [ x] Added copyright headers for new files from `CONTRIBUTING.md`
