### PR TITLE
Pass through query params

### DIFF
--- a/src/main/java/io/mantisrx/api/push/ConnectionBroker.java
+++ b/src/main/java/io/mantisrx/api/push/ConnectionBroker.java
@@ -285,7 +285,7 @@ public class ConnectionBroker {
 
         final String jobId = details.target;
 
-        SinkParameters metricNamesFilter = new SinkParameters.Builder().build();
+        SinkParameters metricNamesFilter = details.getSinkparameters();
         /*
         try {
             SinkParameters.Builder sinkParamsBuilder = new SinkParameters.Builder();

--- a/src/main/java/io/mantisrx/api/push/ConnectionBroker.java
+++ b/src/main/java/io/mantisrx/api/push/ConnectionBroker.java
@@ -286,18 +286,6 @@ public class ConnectionBroker {
         final String jobId = details.target;
 
         SinkParameters metricNamesFilter = details.getSinkparameters();
-        /*
-        try {
-            SinkParameters.Builder sinkParamsBuilder = new SinkParameters.Builder();
-            for (String metric : metricGroups) {
-                sinkParamsBuilder = sinkParamsBuilder.withParameter(METRIC_NAME_STR, metric);
-            }
-
-            metricNamesFilter = sinkParamsBuilder.build();
-        } catch (UnsupportedEncodingException e) {
-            log.error("error encoding sink parameters", e);
-        }
-         */
 
         final MetricsClient<MantisServerSentEvent> metricsClient = workerMetricsClient.getMetricsClientByJobId(jobId,
                 new SseWorkerConnectionFunction(true, new Action1<Throwable>() {


### PR DESCRIPTION
### Context

In the api/v1/metrics API Pass query parameters sent by the user to the target job. This allows users to filter for metrics by name e.g api/v1/metrics/myjob-1?name=worker_stage_inner_output 

### Checklist

- [ x] `./gradlew build` compiles code correctly
- [x ] Added new tests where applicable
- [x ] `./gradlew test` passes all tests
- [x ] Extended README or added javadocs where applicable
- [x ] Added copyright headers for new files from `CONTRIBUTING.md`
