### PR TITLE
Firefox unable to establish WebSocket connection to MantisAPI

### DIFF
--- a/src/main/java/io/mantisrx/api/push/MantisSSEHandler.java
+++ b/src/main/java/io/mantisrx/api/push/MantisSSEHandler.java
@@ -146,8 +146,10 @@ public class MantisSSEHandler extends SimpleChannelInboundHandler<FullHttpReques
 
     private boolean isWebsocketUpgrade(HttpRequest request) {
         HttpHeaders headers = request.headers();
-        return "Upgrade".containsIgnoreCase(headers.get(HttpHeaderNames.CONNECTION)) &&
-                "WebSocket".equalsIgnoreCase(headers.get(HttpHeaderNames.UPGRADE));
+        // Header "Connection" contains "upgrade" (case insensitive) and
+        // Header "Upgrade" equals "websocket" (case insensitive)
+        return headers.get(HttpHeaderNames.CONNECTION).toLowerCase().contains("upgrade") &&
+                headers.get(HttpHeaderNames.UPGRADE).toLowerCase().equals("websocket");
     }
 
 

--- a/src/main/java/io/mantisrx/api/push/MantisSSEHandler.java
+++ b/src/main/java/io/mantisrx/api/push/MantisSSEHandler.java
@@ -146,7 +146,7 @@ public class MantisSSEHandler extends SimpleChannelInboundHandler<FullHttpReques
 
     private boolean isWebsocketUpgrade(HttpRequest request) {
         HttpHeaders headers = request.headers();
-        return "Upgrade".equalsIgnoreCase(headers.get(HttpHeaderNames.CONNECTION)) &&
+        return "Upgrade".containsIgnoreCase(headers.get(HttpHeaderNames.CONNECTION)) &&
                 "WebSocket".equalsIgnoreCase(headers.get(HttpHeaderNames.UPGRADE));
     }
 


### PR DESCRIPTION
### Context

Loosens up the check on isWebsocketUpgrade() so if the Connection header contains the word "Upgrade" it will pass. Previously the check must equal "Upgrade"

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
