### PR TITLE
Replace JCenter with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -58,7 +58,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 tasks.withType(Javadoc).all {


### PR DESCRIPTION
This replaces jcenter with maven central to avoid broken builds in the future

