### PR TITLE
Improve cross region behavior

### DIFF
--- a/src/main/java/io/mantisrx/api/Util.java
+++ b/src/main/java/io/mantisrx/api/Util.java
@@ -32,7 +32,7 @@ import static io.mantisrx.api.Constants.*;
 @UtilityClass
 @Slf4j
 public class Util {
-    private static final int defaultNumRetries = 5;
+    private static final int defaultNumRetries = 2;
 
     public static boolean startsWithAnyOf(final String target, List<String> prefixes) {
         for (String prefix : prefixes) {

--- a/src/main/java/io/mantisrx/api/Util.java
+++ b/src/main/java/io/mantisrx/api/Util.java
@@ -51,6 +51,10 @@ public class Util {
         return System.getenv("EC2_REGION");
     }
 
+    public static boolean isAllRegion(String region) {
+        return region != null && region.trim().equalsIgnoreCase("all");
+    }
+
     //
     // Query Params
     //

--- a/src/main/java/io/mantisrx/api/tunnel/CrossRegionHandler.java
+++ b/src/main/java/io/mantisrx/api/tunnel/CrossRegionHandler.java
@@ -88,7 +88,7 @@ public class CrossRegionHandler extends SimpleChannelInboundHandler<FullHttpRequ
     private Subscription subscription = null;
     private final DynamicIntProperty queueCapacity = new DynamicIntProperty("io.mantisrx.api.push.queueCapacity", 1000);
     private final DynamicIntProperty writeIntervalMillis = new DynamicIntProperty("io.mantisrx.api.push.writeIntervalMillis", 50);
-	private final DynamicStringProperty tunnelRegionsProperty = new DynamicStringProperty("io.mantisrx.api.tunnel.regions", "");
+	private final DynamicStringProperty tunnelRegionsProperty = new DynamicStringProperty("io.mantisrx.api.tunnel.regions", Util.getLocalRegion());
 
 	private List<String> getTunnelRegions() {
 		return Arrays.asList(tunnelRegionsProperty.get().split(","));
@@ -204,7 +204,7 @@ public class CrossRegionHandler extends SimpleChannelInboundHandler<FullHttpRequ
     private void handleRestPost(ChannelHandlerContext ctx, FullHttpRequest request) {
         String uri = getTail(request.uri());
         List<String> regions = getRegion(request.uri()).equals("all")
-                ? Arrays.asList("us-east-1", "us-west-2", "eu-west-1")
+                ? getTunnelRegions()
                 : Collections.singletonList(getRegion(request.uri()));
 
         log.info("Relaying POST URI {} to {}.", uri, regions);
@@ -268,7 +268,7 @@ public class CrossRegionHandler extends SimpleChannelInboundHandler<FullHttpRequ
         final boolean sendThroughTunnelPings = hasTunnelPingParam(request.uri());
         final String uri = uriWithTunnelParamsAdded(getTail(request.uri()));
         List<String> regions = getRegion(request.uri()).equals("all")
-                ? Arrays.asList("us-east-1", "us-west-2", "eu-west-1")
+                ? getTunnelRegions()
                 : Collections.singletonList(getRegion(request.uri()));
 
         log.info("Initiating remote SSE connection to {} in {}.", uri, regions);

--- a/src/main/java/io/mantisrx/api/tunnel/CrossRegionHandler.java
+++ b/src/main/java/io/mantisrx/api/tunnel/CrossRegionHandler.java
@@ -382,9 +382,16 @@ public class CrossRegionHandler extends SimpleChannelInboundHandler<FullHttpRequ
         return uri.replaceFirst("^/region/.*?/", "/");
     }
 
+    /**
+     * Fetches a region from a URI if it contains one, returns garbage if not.
+     *
+     * @param uri The uri from which to fetch the region.
+     * @return The region embedded in the URI, always lower case.
+     * */
     private static String getRegion(String uri) {
         return uri.replaceFirst("^/region/", "")
-                .replaceFirst("/.*$", "");
+                .replaceFirst("/.*$", "")
+                .toLowerCase();
     }
 
     private static String responseToString(List<RegionData> dataList) {


### PR DESCRIPTION
CrossRegionHandler now defaults to the local region in the event of a
property fetch failure. Previously this was blank, guaranteeing a failed
request.

The default number of retries has been reduced from 5 to 2. Excessive
retries were causing needlessly long timeouts. If the retry fails each
subsequent try is unlikely to succeed.

Removed hard coded regions in the cross region handler.

### Context

Mantis API appeared to be failing to contact region `""` today in test, this was the default value for the fast property when it cannot be fetched. Furthermore the timeout took an excessive amount of time due to the large number of retries. The probability of a second and all subsequent retries succeeding is exceedingly low.

Finally I removed two sites with hard coded regions that otherwise needed to be updated when region expansion happened. They now read from the property which will need to be updated.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
