### PR TITLE
Updating Mantis Library to v2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ ext {
     jsonVersion = '20160810'
     junitVersion = '4.10'
     lombokVersion = '1.18.10'
-    mantisClientVersion = '1.3.+'
-    mantisDiscoveryProtoVersion = '1.3.+'
+    mantisClientVersion = '2.0.0-rc.75'
+    mantisDiscoveryProtoVersion = '2.0.0-rc.75'
     mockitoVersion = '1.9.5'
     s3Version = '1.11.566'
     servletApiVersion = '3.1.0'
@@ -59,6 +59,12 @@ targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     mavenCentral()
+    maven {
+        url "https://netflixoss.jfrog.io/artifactory/maven-oss-candidates"
+    }
+    maven {
+        url "https://artifacts-oss.netflix.net/artifactory/maven-oss-snapshots"
+    }
 }
 
 tasks.withType(Javadoc).all {

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,0 +1,223 @@
+{
+    "annotationProcessor": {
+        "org.projectlombok:lombok": {
+            "locked": "1.18.10"
+        }
+    },
+    "compileClasspath": {
+        "com.google.inject:guice": {
+            "locked": "4.1.0"
+        },
+        "com.netflix.blitz4j:blitz4j": {
+            "locked": "1.37.2"
+        },
+        "com.netflix.governator:governator": {
+            "locked": "1.17.13-SNAPSHOT"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "locked": "2.3.1-SNAPSHOT"
+        },
+        "com.netflix.zuul:zuul-groovy": {
+            "locked": "2.3.1-SNAPSHOT"
+        },
+        "com.netflix.zuul:zuul-guice": {
+            "locked": "2.3.1-SNAPSHOT"
+        },
+        "commons-configuration:commons-configuration": {
+            "locked": "1.10"
+        },
+        "io.mantisrx:mantis-client": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-control-plane-client": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-discovery-proto": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-runtime": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-server-worker-client": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mql-jvm": {
+            "locked": "3.4.0"
+        },
+        "io.vavr:vavr": {
+            "locked": "0.10.2"
+        },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.12.0"
+        },
+        "org.projectlombok:lombok": {
+            "locked": "1.18.10"
+        }
+    },
+    "pmd": {
+        "net.sourceforge.pmd:pmd-java": {
+            "locked": "6.26.0"
+        }
+    },
+    "runtimeClasspath": {
+        "com.google.inject:guice": {
+            "locked": "4.1.0"
+        },
+        "com.netflix.blitz4j:blitz4j": {
+            "locked": "1.37.2"
+        },
+        "com.netflix.governator:governator": {
+            "locked": "1.17.13-SNAPSHOT"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "locked": "2.3.1-SNAPSHOT"
+        },
+        "com.netflix.zuul:zuul-groovy": {
+            "locked": "2.3.1-SNAPSHOT"
+        },
+        "com.netflix.zuul:zuul-guice": {
+            "locked": "2.3.1-SNAPSHOT"
+        },
+        "commons-configuration:commons-configuration": {
+            "locked": "1.10"
+        },
+        "io.mantisrx:mantis-client": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-control-plane-client": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-discovery-proto": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-runtime": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-server-worker-client": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mql-jvm": {
+            "locked": "3.4.0"
+        },
+        "io.vavr:vavr": {
+            "locked": "0.10.2"
+        },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.12.0"
+        },
+        "org.projectlombok:lombok": {
+            "locked": "1.18.10"
+        }
+    },
+    "testAnnotationProcessor": {
+        "org.projectlombok:lombok": {
+            "locked": "1.18.10"
+        }
+    },
+    "testCompileClasspath": {
+        "com.google.inject:guice": {
+            "locked": "4.1.0"
+        },
+        "com.netflix.blitz4j:blitz4j": {
+            "locked": "1.37.2"
+        },
+        "com.netflix.governator:governator": {
+            "locked": "1.17.13-SNAPSHOT"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "locked": "2.3.1-SNAPSHOT"
+        },
+        "com.netflix.zuul:zuul-groovy": {
+            "locked": "2.3.1-SNAPSHOT"
+        },
+        "com.netflix.zuul:zuul-guice": {
+            "locked": "2.3.1-SNAPSHOT"
+        },
+        "commons-configuration:commons-configuration": {
+            "locked": "1.10"
+        },
+        "io.mantisrx:mantis-client": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-control-plane-client": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-discovery-proto": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-runtime": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-server-worker-client": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mql-jvm": {
+            "locked": "3.4.0"
+        },
+        "io.vavr:vavr": {
+            "locked": "0.10.2"
+        },
+        "junit:junit": {
+            "locked": "4.13.2"
+        },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.12.0"
+        },
+        "org.projectlombok:lombok": {
+            "locked": "1.18.10"
+        }
+    },
+    "testRuntimeClasspath": {
+        "com.google.inject:guice": {
+            "locked": "4.1.0"
+        },
+        "com.netflix.blitz4j:blitz4j": {
+            "locked": "1.37.2"
+        },
+        "com.netflix.governator:governator": {
+            "locked": "1.17.13-SNAPSHOT"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "locked": "2.3.1-SNAPSHOT"
+        },
+        "com.netflix.zuul:zuul-groovy": {
+            "locked": "2.3.1-SNAPSHOT"
+        },
+        "com.netflix.zuul:zuul-guice": {
+            "locked": "2.3.1-SNAPSHOT"
+        },
+        "commons-configuration:commons-configuration": {
+            "locked": "1.10"
+        },
+        "io.mantisrx:mantis-client": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-control-plane-client": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-discovery-proto": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-runtime": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mantis-server-worker-client": {
+            "locked": "2.0.0-rc.75"
+        },
+        "io.mantisrx:mql-jvm": {
+            "locked": "3.4.0"
+        },
+        "io.vavr:vavr": {
+            "locked": "0.10.2"
+        },
+        "junit:junit": {
+            "locked": "4.13.2"
+        },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.12.0"
+        },
+        "org.projectlombok:lombok": {
+            "locked": "1.18.10"
+        }
+    }
+}

--- a/src/main/java/io/mantisrx/api/MantisAPIModule.java
+++ b/src/main/java/io/mantisrx/api/MantisAPIModule.java
@@ -22,6 +22,10 @@ import com.netflix.zuul.filters.FilterRegistry;
 import com.netflix.zuul.filters.MutableFilterRegistry;
 import com.netflix.zuul.groovy.GroovyCompiler;
 import com.netflix.zuul.groovy.GroovyFileFilter;
+import io.mantisrx.server.core.Configurations;
+import io.mantisrx.server.core.CoreConfiguration;
+import io.mantisrx.server.master.client.HighAvailabilityServices;
+import io.mantisrx.server.master.client.HighAvailabilityServicesUtil;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
@@ -107,7 +111,9 @@ public class MantisAPIModule extends AbstractModule {
             props.put(key, configuration.getString(key));
         });
 
-        return new MasterClientWrapper(props);
+        HighAvailabilityServices haServices = HighAvailabilityServicesUtil.createHAServices(
+            Configurations.frmProperties(props, CoreConfiguration.class));
+        return new MasterClientWrapper(haServices.getMasterClientApi());
     }
 
     @Provides @Singleton MantisClient provideMantisClient(AbstractConfiguration configuration) {


### PR DESCRIPTION
### Context

I need to update mantis-api to depend on the latest version of Mantis because the one that it depends on right now is outdated. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
