### PR TITLE
Make SSE and WebSocket handlers unsubscribe when inactive and exception caught

### DIFF
--- a/src/main/java/io/mantisrx/api/push/MantisSSEHandler.java
+++ b/src/main/java/io/mantisrx/api/push/MantisSSEHandler.java
@@ -159,21 +159,21 @@ public class MantisSSEHandler extends SimpleChannelInboundHandler<FullHttpReques
 
     @Override
     public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
-        log.info("Channel is unregistered: {}", ctx.channel());
+        log.info("Channel {} is unregistered. URI: {}", ctx.channel(), uri);
         unsubscribeIfSubscribed();
         super.channelUnregistered(ctx);
     }
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        log.info("Channel is inactive: {}", ctx.channel());
+        log.info("Channel {} is inactive. URI: {}", ctx.channel(), uri);
         unsubscribeIfSubscribed();
         super.channelInactive(ctx);
     }
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        log.warn("Exception caught for channel {}", ctx.channel(), cause);
+        log.warn("Exception caught by channel {}. URI: {}", ctx.channel(), uri, cause);
         unsubscribeIfSubscribed();
         ctx.close();
     }

--- a/src/main/java/io/mantisrx/api/push/MantisSSEHandler.java
+++ b/src/main/java/io/mantisrx/api/push/MantisSSEHandler.java
@@ -14,7 +14,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.*;
-import io.vavr.control.Option;
 import lombok.extern.slf4j.Slf4j;
 import mantis.io.reactivex.netty.RxNetty;
 import mantis.io.reactivex.netty.channel.StringTransformer;
@@ -38,13 +37,15 @@ import java.util.concurrent.TimeUnit;
  */
 @Slf4j
 public class MantisSSEHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+    private final DynamicIntProperty queueCapacity = new DynamicIntProperty("io.mantisrx.api.push.queueCapacity", 1000);
+    private final DynamicIntProperty writeIntervalMillis = new DynamicIntProperty("io.mantisrx.api.push.writeIntervalMillis", 50);
 
     private final ConnectionBroker connectionBroker;
     private final HighAvailabilityServices highAvailabilityServices;
     private final List<String> pushPrefixes;
+
     private Subscription subscription;
-    private final DynamicIntProperty queueCapacity = new DynamicIntProperty("io.mantisrx.api.push.queueCapacity", 1000);
-    private final DynamicIntProperty writeIntervalMillis = new DynamicIntProperty("io.mantisrx.api.push.writeIntervalMillis", 50);
+    private String uri;
 
     public MantisSSEHandler(ConnectionBroker connectionBroker, HighAvailabilityServices highAvailabilityServices,
                             List<String> pushPrefixes) {
@@ -75,7 +76,7 @@ public class MantisSSEHandler extends SimpleChannelInboundHandler<FullHttpReques
             response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
             ctx.writeAndFlush(response);
 
-            final String uri = request.uri();
+            uri = request.uri();
             final PushConnectionDetails pcd =
                     isSubmitAndConnect(request)
                             ? new PushConnectionDetails(uri, jobSubmit(request), PushConnectionDetails.TARGET_TYPE.CONNECT_BY_ID, io.vavr.collection.List.empty())
@@ -122,11 +123,6 @@ public class MantisSSEHandler extends SimpleChannelInboundHandler<FullHttpReques
                         }
                     })
                     .subscribe();
-
-
-                    /*
-                     */
-
         } else {
             ctx.fireChannelRead(request.retain());
         }
@@ -162,20 +158,32 @@ public class MantisSSEHandler extends SimpleChannelInboundHandler<FullHttpReques
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        if (this.subscription != null && !this.subscription.isUnsubscribed()) {
-            this.subscription.unsubscribe();
-        }
-        cause.printStackTrace();
-        ctx.close();
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        log.info("Channel is unregistered: {}", ctx.channel());
+        unsubscribeIfSubscribed();
+        super.channelUnregistered(ctx);
     }
 
     @Override
-    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
-        if (this.subscription != null && !this.subscription.isUnsubscribed()) {
-            this.subscription.unsubscribe();
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        log.info("Channel is inactive: {}", ctx.channel());
+        unsubscribeIfSubscribed();
+        super.channelInactive(ctx);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.warn("Exception caught for channel {}", ctx.channel(), cause);
+        unsubscribeIfSubscribed();
+        ctx.close();
+    }
+
+    /** Unsubscribe if it's subscribed. */
+    private void unsubscribeIfSubscribed() {
+        if (subscription != null && !subscription.isUnsubscribed()) {
+            log.info("SSE unsubscribing subscription with URI: {}", uri);
+            subscription.unsubscribe();
         }
-        super.channelUnregistered(ctx);
     }
 
     public String jobSubmit(FullHttpRequest request) {

--- a/src/main/java/io/mantisrx/api/push/MantisWebSocketFrameHandler.java
+++ b/src/main/java/io/mantisrx/api/push/MantisWebSocketFrameHandler.java
@@ -42,7 +42,7 @@ public class MantisWebSocketFrameHandler extends SimpleChannelInboundHandler<Tex
             uri = complete.requestUri();
             final PushConnectionDetails pcd = PushConnectionDetails.from(uri);
 
-            log.info("Request to UIR '{}' is a WebSSocket upgrade, removing the SSE handler", uri);
+            log.info("Request to URI '{}' is a WebSSocket upgrade, removing the SSE handler", uri);
             if (ctx.pipeline().get(MantisSSEHandler.class) != null) {
                 ctx.pipeline().remove(MantisSSEHandler.class);
             }
@@ -85,21 +85,21 @@ public class MantisWebSocketFrameHandler extends SimpleChannelInboundHandler<Tex
 
     @Override
     public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
-        log.info("Channel is unregistered: {}", ctx.channel());
+        log.info("Channel {} is unregistered. URI: {}", ctx.channel(), uri);
         unsubscribeIfSubscribed();
         super.channelUnregistered(ctx);
     }
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        log.info("Channel is inactive: {}", ctx.channel());
+        log.info("Channel {} is inactive. URI: {}", ctx.channel(), uri);
         unsubscribeIfSubscribed();
         super.channelInactive(ctx);
     }
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        log.warn("Exception caught for channel {}", ctx.channel(), cause);
+        log.warn("Exception caught by channel {}. URI: {}", ctx.channel(), uri, cause);
         unsubscribeIfSubscribed();
         // This is the tail of handlers. We should close the channel between the server and the client,
         // essentially causing the client to disconnect and terminate.

--- a/src/main/java/io/mantisrx/api/push/MantisWebSocketFrameHandler.java
+++ b/src/main/java/io/mantisrx/api/push/MantisWebSocketFrameHandler.java
@@ -23,9 +23,11 @@ import rx.Subscription;
 @Slf4j
 public class MantisWebSocketFrameHandler extends SimpleChannelInboundHandler<TextWebSocketFrame> {
     private final ConnectionBroker connectionBroker;
-    private Subscription subscription;
     private final DynamicIntProperty queueCapacity = new DynamicIntProperty("io.mantisrx.api.push.queueCapacity", 1000);
     private final DynamicIntProperty writeIntervalMillis = new DynamicIntProperty("io.mantisrx.api.push.writeIntervalMillis", 50);
+
+    private Subscription subscription;
+    private String uri;
 
     public MantisWebSocketFrameHandler(ConnectionBroker broker) {
         super(true);
@@ -35,15 +37,15 @@ public class MantisWebSocketFrameHandler extends SimpleChannelInboundHandler<Tex
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt.getClass() == WebSocketServerProtocolHandler.HandshakeComplete.class) {
+            WebSocketServerProtocolHandler.HandshakeComplete complete = (WebSocketServerProtocolHandler.HandshakeComplete) evt;
 
+            uri = complete.requestUri();
+            final PushConnectionDetails pcd = PushConnectionDetails.from(uri);
+
+            log.info("Request to UIR '{}' is a WebSSocket upgrade, removing the SSE handler", uri);
             if (ctx.pipeline().get(MantisSSEHandler.class) != null) {
                 ctx.pipeline().remove(MantisSSEHandler.class);
             }
-
-            WebSocketServerProtocolHandler.HandshakeComplete complete = (WebSocketServerProtocolHandler.HandshakeComplete) evt;
-
-            final String uri = complete.requestUri();
-            final PushConnectionDetails pcd = PushConnectionDetails.from(uri);
 
             final String[] tags = Util.getTaglist(uri, pcd.target);
             Counter numDroppedBytesCounter = SpectatorUtils.newCounter(Constants.numDroppedBytesCounterName, pcd.target, tags);
@@ -51,7 +53,7 @@ public class MantisWebSocketFrameHandler extends SimpleChannelInboundHandler<Tex
             Counter numMessagesCounter = SpectatorUtils.newCounter(Constants.numMessagesCounterName, pcd.target, tags);
             Counter numBytesCounter = SpectatorUtils.newCounter(Constants.numBytesCounterName, pcd.target, tags);
 
-            BlockingQueue<String> queue = new LinkedBlockingQueue<String>(queueCapacity.get());
+            BlockingQueue<String> queue = new LinkedBlockingQueue<>(queueCapacity.get());
 
             this.subscription = this.connectionBroker.connect(pcd)
                     .mergeWith(Observable.interval(writeIntervalMillis.get(), TimeUnit.MILLISECONDS)
@@ -75,7 +77,6 @@ public class MantisWebSocketFrameHandler extends SimpleChannelInboundHandler<Tex
                         }
                     })
                     .subscribe();
-
         } else {
             ReferenceCountUtil.retain(evt);
             super.userEventTriggered(ctx, evt);
@@ -84,13 +85,37 @@ public class MantisWebSocketFrameHandler extends SimpleChannelInboundHandler<Tex
 
     @Override
     public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
-        if (subscription != null && !subscription.isUnsubscribed()) {
-            this.subscription.unsubscribe();
-        }
+        log.info("Channel is unregistered: {}", ctx.channel());
+        unsubscribeIfSubscribed();
+        super.channelUnregistered(ctx);
     }
 
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, TextWebSocketFrame msg) throws Exception {
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        log.info("Channel is inactive: {}", ctx.channel());
+        unsubscribeIfSubscribed();
+        super.channelInactive(ctx);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.warn("Exception caught for channel {}", ctx.channel(), cause);
+        unsubscribeIfSubscribed();
+        // This is the tail of handlers. We should close the channel between the server and the client,
+        // essentially causing the client to disconnect and terminate.
+        ctx.close();
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, TextWebSocketFrame msg) {
         // No op.
+    }
+
+    /** Unsubscribe if it's subscribed. */
+    private void unsubscribeIfSubscribed() {
+        if (subscription != null && !subscription.isUnsubscribed()) {
+            log.info("WebSocket unsubscribing subscription with URI: {}", uri);
+            subscription.unsubscribe();
+        }
     }
 }


### PR DESCRIPTION
### Context

Currently the `MantisWebSocketFrameHandler` does not unsubscribe the subscriptions when exceptions got caught or the connection became inactive. That could introduce connection leakage where source jobs still keep push subscriptions to the publisher.

This PR unsubscribes the subscription in those cases. As the previous investigation shows this could also happen with SSE handler, this PR tries to close the subscription in both `channelInactive` and `channelUnregistered` callbacks. In future when we are sure we need only one of them, we can remove the other. For debugging purpose, we also add some logging.

### Checklist

- [X] `./gradlew build` compiles code correctly
- [ ] ~Added new tests where applicable~
- [X] `./gradlew test` passes all tests
- [ ] ~Extended README or added javadocs where applicable~
- [ ] ~Added copyright headers for new files from `CONTRIBUTING.md`~
