### PR TITLE
Support csv for region in cross region uri

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ ext {
     junitVersion = '4.10'
     lombokVersion = '1.18.10'
     mantisVersion = '2.0.45'
-    mockitoVersion = '1.9.5'
+    mockitoVersion = '3.+'
     s3Version = '1.11.566'
     servletApiVersion = '3.1.0'
     spectatorVersion = '0.92.+'
@@ -109,6 +109,7 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:$lombokVersion"
 
     testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation"org.projectlombok:lombok:$lombokVersion"
     testAnnotationProcessor "org.projectlombok:lombok:$lombokVersion"
 }

--- a/src/main/java/io/mantisrx/api/Util.java
+++ b/src/main/java/io/mantisrx/api/Util.java
@@ -51,10 +51,6 @@ public class Util {
         return System.getenv("EC2_REGION");
     }
 
-    public static boolean isAllRegion(String region) {
-        return region != null && region.trim().equalsIgnoreCase("all");
-    }
-
     //
     // Query Params
     //

--- a/src/main/java/io/mantisrx/api/tunnel/CrossRegionHandler.java
+++ b/src/main/java/io/mantisrx/api/tunnel/CrossRegionHandler.java
@@ -17,8 +17,6 @@
 package io.mantisrx.api.tunnel;
 
 import static io.mantisrx.api.Constants.OriginRegionTagName;
-import static io.mantisrx.api.Constants.SSE_DATA_PREFIX;
-import static io.mantisrx.api.Constants.SSE_DATA_SUFFIX;
 import static io.mantisrx.api.Constants.TagNameValDelimiter;
 import static io.mantisrx.api.Constants.TagsParamName;
 import static io.mantisrx.api.Constants.TunnelPingMessage;
@@ -97,15 +95,18 @@ public class CrossRegionHandler extends SimpleChannelInboundHandler<FullHttpRequ
     private ScheduledFuture drainFuture;
     private final DynamicIntProperty queueCapacity = new DynamicIntProperty("io.mantisrx.api.push.queueCapacity", 1000);
     private final DynamicIntProperty writeIntervalMillis = new DynamicIntProperty("io.mantisrx.api.push.writeIntervalMillis", 50);
-	private final DynamicStringProperty tunnelRegionsProperty = new DynamicStringProperty("io.mantisrx.api.tunnel.regions", Util.getLocalRegion());
+    private final DynamicStringProperty tunnelRegionsProperty = new DynamicStringProperty("io.mantisrx.api.tunnel.regions", Util.getLocalRegion());
 
-	private List<String> getTunnelRegions() {
-		return Arrays.asList(tunnelRegionsProperty.get().split(","))
-            .stream()
-            .map(String::trim)
-            .map(String::toLowerCase)
-            .collect(Collectors.toList());
-	}
+    private List<String> getTunnelRegions() {
+        return parseRegionCsv(tunnelRegionsProperty.get());
+    }
+
+    private List<String> parseRegionCsv(String regionCsv) {
+        return Arrays.stream(regionCsv.split(","))
+                .map(String::trim)
+                .map(String::toLowerCase)
+                .collect(Collectors.toList());
+    }
 
     public CrossRegionHandler(
             List<String> pushPrefixes,
@@ -164,10 +165,19 @@ public class CrossRegionHandler extends SimpleChannelInboundHandler<FullHttpRequ
                 .addListener(__ -> ctx.close());
     }
 
+    private List<String> parseRegionsInUri(String uri) {
+        final String regionString = getRegion(uri);
+        if (isAllRegion(regionString)) {
+            return getTunnelRegions();
+        } else if (regionString.contains(",")) {
+            return parseRegionCsv(regionString);
+        } else {
+            return Collections.singletonList(regionString);
+        }
+    }
+
     private void handleRestGet(ChannelHandlerContext ctx, FullHttpRequest request) {
-        List<String> regions = Util.isAllRegion(getRegion(request.uri()))
-                ? getTunnelRegions()
-                : Collections.singletonList(getRegion(request.uri()));
+        List<String> regions = parseRegionsInUri(request.uri());
 
         String uri = getTail(request.uri());
         Observable.from(regions)
@@ -216,9 +226,7 @@ public class CrossRegionHandler extends SimpleChannelInboundHandler<FullHttpRequ
 
     private void handleRestPost(ChannelHandlerContext ctx, FullHttpRequest request) {
         String uri = getTail(request.uri());
-        List<String> regions = Util.isAllRegion(getRegion(request.uri()))
-                ? getTunnelRegions()
-                : Collections.singletonList(getRegion(request.uri()));
+        List<String> regions = parseRegionsInUri(uri);
 
         log.info("Relaying POST URI {} to {}.", uri, regions);
         final AtomicReference<Throwable> ref = new AtomicReference<>();
@@ -280,9 +288,7 @@ public class CrossRegionHandler extends SimpleChannelInboundHandler<FullHttpRequ
 
         final boolean sendThroughTunnelPings = hasTunnelPingParam(request.uri());
         final String uri = uriWithTunnelParamsAdded(getTail(request.uri()));
-        List<String> regions = Util.isAllRegion(getRegion(request.uri()))
-                ? getTunnelRegions()
-                : Collections.singletonList(getRegion(request.uri()));
+        List<String> regions = parseRegionsInUri(request.uri());
 
         log.info("Initiating remote SSE connection to {} in {}.", uri, regions);
         PushConnectionDetails pcd = PushConnectionDetails.from(uri, regions);
@@ -448,6 +454,14 @@ public class CrossRegionHandler extends SimpleChannelInboundHandler<FullHttpRequ
                 .replaceFirst("/.*$", "")
                 .trim()
                 .toLowerCase();
+    }
+
+    /**
+     * Checks for a specific `all` string to connect to all regions
+     * specified by {@link CrossRegionHandler#getTunnelRegions()}
+     */
+    private static boolean isAllRegion(String region) {
+        return region != null && region.trim().equalsIgnoreCase("all");
     }
 
     private static String responseToString(List<RegionData> dataList) {

--- a/src/main/java/io/mantisrx/api/tunnel/CrossRegionHandler.java
+++ b/src/main/java/io/mantisrx/api/tunnel/CrossRegionHandler.java
@@ -16,42 +16,16 @@
 
 package io.mantisrx.api.tunnel;
 
-import static io.mantisrx.api.Constants.OriginRegionTagName;
-import static io.mantisrx.api.Constants.TagNameValDelimiter;
-import static io.mantisrx.api.Constants.TagsParamName;
-import static io.mantisrx.api.Constants.TunnelPingMessage;
-import static io.mantisrx.api.Constants.TunnelPingParamName;
-import static io.mantisrx.api.Util.getLocalRegion;
-
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-
+import com.google.common.annotations.VisibleForTesting;
 import com.netflix.config.DynamicIntProperty;
 import com.netflix.config.DynamicStringProperty;
 import com.netflix.spectator.api.Counter;
 import com.netflix.zuul.netty.SpectatorUtils;
-
-import io.mantisrx.shaded.com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import io.mantisrx.api.Constants;
 import io.mantisrx.api.Util;
 import io.mantisrx.api.push.ConnectionBroker;
 import io.mantisrx.api.push.PushConnectionDetails;
+import io.mantisrx.shaded.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -76,9 +50,34 @@ import mantis.io.reactivex.netty.channel.StringTransformer;
 import mantis.io.reactivex.netty.protocol.http.client.HttpClient;
 import mantis.io.reactivex.netty.protocol.http.client.HttpClientRequest;
 import mantis.io.reactivex.netty.protocol.http.client.HttpClientResponse;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 import rx.Observable;
 import rx.Scheduler;
 import rx.Subscription;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static io.mantisrx.api.Constants.OriginRegionTagName;
+import static io.mantisrx.api.Constants.TagNameValDelimiter;
+import static io.mantisrx.api.Constants.TagsParamName;
+import static io.mantisrx.api.Constants.TunnelPingMessage;
+import static io.mantisrx.api.Constants.TunnelPingParamName;
+import static io.mantisrx.api.Util.getLocalRegion;
 
 @Slf4j
 public class CrossRegionHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
@@ -96,17 +95,6 @@ public class CrossRegionHandler extends SimpleChannelInboundHandler<FullHttpRequ
     private final DynamicIntProperty queueCapacity = new DynamicIntProperty("io.mantisrx.api.push.queueCapacity", 1000);
     private final DynamicIntProperty writeIntervalMillis = new DynamicIntProperty("io.mantisrx.api.push.writeIntervalMillis", 50);
     private final DynamicStringProperty tunnelRegionsProperty = new DynamicStringProperty("io.mantisrx.api.tunnel.regions", Util.getLocalRegion());
-
-    private List<String> getTunnelRegions() {
-        return parseRegionCsv(tunnelRegionsProperty.get());
-    }
-
-    private List<String> parseRegionCsv(String regionCsv) {
-        return Arrays.stream(regionCsv.split(","))
-                .map(String::trim)
-                .map(String::toLowerCase)
-                .collect(Collectors.toList());
-    }
 
     public CrossRegionHandler(
             List<String> pushPrefixes,
@@ -165,7 +153,20 @@ public class CrossRegionHandler extends SimpleChannelInboundHandler<FullHttpRequ
                 .addListener(__ -> ctx.close());
     }
 
-    private List<String> parseRegionsInUri(String uri) {
+    @VisibleForTesting
+    List<String> getTunnelRegions() {
+        return parseRegionCsv(tunnelRegionsProperty.get());
+    }
+
+    private static List<String> parseRegionCsv(String regionCsv) {
+        return Arrays.stream(regionCsv.split(","))
+                .map(String::trim)
+                .map(String::toLowerCase)
+                .collect(Collectors.toList());
+    }
+
+    @VisibleForTesting
+    List<String> parseRegionsInUri(String uri) {
         final String regionString = getRegion(uri);
         if (isAllRegion(regionString)) {
             return getTunnelRegions();

--- a/src/test/java/io/mantisrx/api/tunnel/CrossRegionHandlerTest.java
+++ b/src/test/java/io/mantisrx/api/tunnel/CrossRegionHandlerTest.java
@@ -1,0 +1,32 @@
+package io.mantisrx.api.tunnel;
+
+import com.google.common.collect.ImmutableList;
+import io.mantisrx.api.push.ConnectionBroker;
+import junit.framework.TestCase;
+import org.junit.Test;
+import rx.Scheduler;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class CrossRegionHandlerTest extends TestCase {
+
+    @Test
+    public void testParseUriRegion() {
+
+        CrossRegionHandler regionHandler = spy(new CrossRegionHandler(ImmutableList.of(), mock(MantisCrossRegionalClient.class), mock(ConnectionBroker.class), mock(Scheduler.class)));
+        doReturn(ImmutableList.of("us-east-1", "eu-west-1")).when(regionHandler).getTunnelRegions();
+
+        assertEquals(ImmutableList.of("us-east-1"), regionHandler.parseRegionsInUri("/region/us-east-1/foobar"));
+        assertEquals(ImmutableList.of("us-east-2"), regionHandler.parseRegionsInUri("/region/us-east-2/foobar"));
+        assertEquals(ImmutableList.of("us-east-1", "eu-west-1"), regionHandler.parseRegionsInUri("/region/all/foobar"));
+        assertEquals(ImmutableList.of("us-east-1", "eu-west-1"), regionHandler.parseRegionsInUri("/region/ALL/foobar"));
+
+        doReturn(ImmutableList.of("us-east-1", "eu-west-1", "us-west-2")).when(regionHandler).getTunnelRegions();
+        assertEquals(ImmutableList.of("us-east-1", "eu-west-1", "us-west-2"), regionHandler.parseRegionsInUri("/region/ALL/foobar"));
+
+        assertEquals(ImmutableList.of("us-east-1", "us-east-2"), regionHandler.parseRegionsInUri("/region/us-east-1,us-east-2/foobar"));
+        assertEquals(ImmutableList.of("us-east-1", "us-west-2"), regionHandler.parseRegionsInUri("/region/us-east-1,us-west-2/foobar"));
+    }
+}


### PR DESCRIPTION
### Context

Currently we support cross region traffic for a specific region OR `all` regions. `all` regions translate to shared fast property `io.mantisrx.api.tunnel.regions` accessed in `getTunnelRegions`.

This PR allows incoming requests to specify the regions to connect to. 
This comes in handy when you only want to connect to a subset of regions OR when you want to connect to different set of regions than configured in the shared fast property.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
