### PR TITLE
Make mantis api jdk17 runtime compatible 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
     jsonVersion = '20160810'
     junitVersion = '4.10'
     lombokVersion = '1.18.10'
-    mantisVersion = '2.0.98'
+    mantisVersion = '2.0.99'
     mockitoVersion = '3.+'
     s3Version = '1.11.566'
     servletApiVersion = '3.1.0'

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -33,19 +33,19 @@
             "locked": "1.8"
         },
         "io.mantisrx:mantis-client": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-control-plane-client": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-discovery-proto": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-runtime": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-server-worker-client": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mql-jvm": {
             "locked": "3.4.0"
@@ -88,19 +88,19 @@
             "locked": "1.8"
         },
         "io.mantisrx:mantis-client": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-control-plane-client": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-discovery-proto": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-runtime": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-server-worker-client": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mql-jvm": {
             "locked": "3.4.0"
@@ -143,19 +143,19 @@
             "locked": "1.8"
         },
         "io.mantisrx:mantis-client": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-control-plane-client": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-discovery-proto": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-runtime": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-server-worker-client": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mql-jvm": {
             "locked": "3.4.0"
@@ -199,19 +199,19 @@
             "locked": "1.8"
         },
         "io.mantisrx:mantis-client": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-control-plane-client": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-discovery-proto": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-runtime": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mantis-server-worker-client": {
-            "locked": "2.0.98"
+            "locked": "2.0.99"
         },
         "io.mantisrx:mql-jvm": {
             "locked": "3.4.0"

--- a/src/main/java/io/mantisrx/api/MantisAPIModule.java
+++ b/src/main/java/io/mantisrx/api/MantisAPIModule.java
@@ -61,7 +61,7 @@ import io.mantisrx.api.tunnel.NoOpCrossRegionalClient;
 import io.mantisrx.client.MantisClient;
 import io.mantisrx.server.worker.client.WorkerMetricsClient;
 import io.mantisrx.shaded.org.apache.curator.framework.listen.Listenable;
-import io.mantisrx.shaded.org.apache.curator.framework.listen.ListenerContainer;
+import io.mantisrx.shaded.org.apache.curator.framework.listen.StandardListenerManager;
 import org.apache.commons.configuration.AbstractConfiguration;
 import rx.Scheduler;
 import rx.schedulers.Schedulers;
@@ -153,7 +153,7 @@ public class MantisAPIModule extends AbstractModule {
         return new ConfigurationBasedAppStreamStore.ConfigSource() {
             @Override
             public Listenable<ConfigurationBasedAppStreamStore.ConfigurationChangeListener> getListenable() {
-                return new ListenerContainer<>();
+                return StandardListenerManager.standard();
             }
 
             @Override


### PR DESCRIPTION
### Context
Upgrade to make this jdk17+ runtime compatible.
(e.g. shaded oss mantis curator version).

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
